### PR TITLE
Fix:uuidが空のユーザーにuuidを割り当てるよう変更

### DIFF
--- a/app/controllers/api/sessions_controller.rb
+++ b/app/controllers/api/sessions_controller.rb
@@ -6,6 +6,7 @@ class Api::SessionsController < ApplicationController
   end
 
   def create
+    binding.pry
     if params[:email]
       user = User.authenticate(params[:email], params[:password])
     else
@@ -13,6 +14,10 @@ class Api::SessionsController < ApplicationController
       auto_login(user)
     end
     raise ActiveRecord::RecordNotFound unless user
+
+    if user.uuid == nil
+      user.update(uuid: SecureRandom.uuid)
+    end
 
     token = user.create_tokens
     render json: { token: token }

--- a/app/controllers/api/sessions_controller.rb
+++ b/app/controllers/api/sessions_controller.rb
@@ -6,7 +6,6 @@ class Api::SessionsController < ApplicationController
   end
 
   def create
-    binding.pry
     if params[:email]
       user = User.authenticate(params[:email], params[:password])
     else


### PR DESCRIPTION
- 既存のユーザーに対してuuidが空の場合にuuidを割り当てるようにした